### PR TITLE
Control segment match ratio

### DIFF
--- a/src/SpawnerWrapper.cpp
+++ b/src/SpawnerWrapper.cpp
@@ -75,7 +75,7 @@ public:
 };
 
 
-extern "C" CTaskSpawner * TaskSpawner_Spawn(CInputVolume * pre, CInputVolume * post, uint32_t * segments, uint32_t segmentCount) {
+extern "C" CTaskSpawner * TaskSpawner_Spawn(CInputVolume * pre, CInputVolume * post, uint32_t * segments, uint32_t segmentCount, double matchRatio) {
   std::set<uint32_t> selected(segments, segments + segmentCount);
 
   size_t metadataLength = strlen(pre->metadata);
@@ -103,7 +103,7 @@ extern "C" CTaskSpawner * TaskSpawner_Spawn(CInputVolume * pre, CInputVolume * p
 
   // Do Important Stuff
   std::vector<std::map<uint32_t, uint32_t>> seeds;
-  get_seeds(seeds, pre_volume, selected, post_volume);
+  get_seeds(seeds, pre_volume, selected, post_volume, matchRatio);
 
   return new CTaskSpawner(seeds);
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]) {
   post.segmentationLength = post_segmentation_len;
   post.segmentation = (uint8_t *)post_segmentation;
 
-  CTaskSpawner * spawn = TaskSpawner_Spawn(&pre, &post, &seg[0], seg.size());
+  CTaskSpawner * spawn = TaskSpawner_Spawn(&pre, &post, &seg[0], seg.size(), 1.0);
 
   TaskSpawner_Release(spawn);
 


### PR DESCRIPTION
Chooses all post-side segments with at least `matchRatio` of their voxels present in the parent cube. (0.5 == EW behavior, 1.0: exact matches only)

Fallback: Some weighted function that will choose a single best match while trying to preserve a minimum segment size. Magic.
