### PR TITLE
Spawning tweaks

### DIFF
--- a/include/SpawnHelper.h
+++ b/include/SpawnHelper.h
@@ -248,7 +248,6 @@ std::map<uint32_t, uint32_t> makeSeed(const std::set<uint32_t>& bundle, const st
 /*****************************************************************/
 
 void get_seeds(std::vector<std::map<uint32_t, uint32_t>> &seeds, const CVolume &pre, const std::set<uint32_t> &selected, const CVolume &post, double matchRatio) {
-  //TODO: log "Getting Seeds\n" << pre.Endpoint() << '\n' << post.Endpoint();
   seeds.clear();
   zi::wall_timer t;
   t.reset();
@@ -264,8 +263,8 @@ void get_seeds(std::vector<std::map<uint32_t, uint32_t>> &seeds, const CVolume &
 
   int64_t overlap = getOverlap(preBoundsWorld, postBoundsWorld, dir);
 
-  vmml::AABB<int64_t> overlapWorld = getOverlapRegion(preBoundsWorld, postBoundsWorld, dir, overlap/2);
-  if (overlapWorld.isEmpty()) {
+  vmml::AABB<int64_t> postHalfOverlapWorld = getOverlapRegion(preBoundsWorld, postBoundsWorld, dir, overlap/2);
+  if (postHalfOverlapWorld.isEmpty()) {
     std::cout << "Boxes do not overlap.\n";
     return;
   }
@@ -278,12 +277,16 @@ void get_seeds(std::vector<std::map<uint32_t, uint32_t>> &seeds, const CVolume &
     }
   }
 
-  vmml::AABB<int64_t> roiWorld = intersect(overlapWorld, segmentBoundsWorld);
-  if (roiWorld.isEmpty()) {
-    std::cout << "No segments in non-fudge area.\n";
+  vmml::AABB<int64_t> postHalfROIWorld = intersect(postHalfOverlapWorld, segmentBoundsWorld);
+  if (postHalfROIWorld.isEmpty()) {
+    std::cout << "No segments in post half of overlap.\n";
     return;
   }
 
+  
+
+  vmml::AABB<int64_t> overlapWorld = intersect(preBoundsWorld, postBoundsWorld);
+  vmml::AABB<int64_t> roiWorld = intersect(overlapWorld, segmentBoundsWorld);
 
   vmml::AABB<int64_t> preVolumeROI = vmml::subtractVector(roiWorld, preBoundsWorld.getMin());
   vmml::AABB<int64_t> postVolumeROI = vmml::subtractVector(roiWorld, postBoundsWorld.getMin());

--- a/include/SpawnHelper.h
+++ b/include/SpawnHelper.h
@@ -244,7 +244,7 @@ std::map<uint32_t, uint32_t> makeSeed(const std::set<uint32_t>& bundle, const st
   }
 
   if (ret.size() == 0) {
-    std::cout << "No perfect seed found. Chose seg " << bestCandidate << "\n";
+    std::cout << "No perfect seed found. Chose seg " << bestCandidate << " with " << mappingCounts.at(bestCandidate) << " / " << bestCandidateSize << " voxels matching.\n";
     ret[bestCandidate] = bestCandidateSize;
   }
 
@@ -282,6 +282,7 @@ void get_seeds(std::vector<std::map<uint32_t, uint32_t>> &seeds, const CVolume &
       segmentBoundsWorld.merge(vmml::divideVector(pre.GetSegmentBoundsWorld(segID), res));
     }
   }
+  segmentBoundsWorld = vmml::dilate(segmentBoundsWorld, vmml::Vector<3, int64_t>(1, 1, 1)); // had some issues with bounding boxes being one voxel off...
 
   vmml::AABB<int64_t> postHalfROIWorld = intersect(postHalfOverlapWorld, segmentBoundsWorld);
   if (postHalfROIWorld.isEmpty()) {

--- a/include/Volume.h
+++ b/include/Volume.h
@@ -50,6 +50,7 @@ private:
   MetaDataType               segment_size_type;
   uint8_t                    segment_id_type_size;
   int64_t                    segment_count;
+  int64_t                    segment_max_id;
   CSegments                * segments;
 
 public:
@@ -63,6 +64,7 @@ public:
   const std::string &              GetResolutionUnit() const;
   uint8_t                          GetSegmentTypeSize() const;
   int64_t                          GetSegmentCount() const;
+  int64_t                          GetSegmentMaxId() const;
 
 };
 
@@ -132,6 +134,7 @@ class CVolume {
   const vmml::AABB<int64_t> &      GetPhysicalBounds() const;
   const vmml::Vector<3, int64_t> & GetVoxelResolution() const;
   int64_t                          GetSegmentCount() const;
+  int64_t                          GetSegmentMaxId() const;
   const vmml::AABB<int64_t> &      GetSegmentBoundsWorld(int64_t segID) const;
   const vmml::AABB<int64_t> &      GetSegmentBoundsVolume(int64_t segID) const;
   int64_t                          GetSegmentSizeVoxel(int64_t segID) const;


### PR DESCRIPTION
Switch margin from fixed value 5 to half overlap.
* Everything within half overlap to the boundary of the pre-side will trigger spawning
* Everything within half overlap to the boundary of the post-side will be considered as seed piece
* small increase in generated tasks, but also more reliable seed pieces (hopefully)

Variable `match_ratio`, which controls at which ratio a post-side segment's voxels match the preside selection well enough to be chosen as seed. (0.6 for E2198, 0.9999 for all datasets with nearly consistent segmentation)